### PR TITLE
Fix bug for add and remove command

### DIFF
--- a/gh-project
+++ b/gh-project
@@ -69,12 +69,10 @@ list() {
 edit() {
   local -r cmd="${1}"
   local -r number="${2}"
-  local project="${3}"
-  local -r flags="${*:4}"
+  local -r flags="${*:3}"
 
-  if [[ -z "${project}" ]]; then
-    project="$(list "${flags[@]}" | fzf)"
-  fi
+  local project
+  project="$(list "${flags[@]}" | fzf)"
 
   local op
   case $cmd in


### PR DESCRIPTION
Fixed the bug where the flag `--org` isn't passed to the commands `add` and `remove`.